### PR TITLE
Update ColorPicker.js

### DIFF
--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -79,8 +79,9 @@ class ColorPicker extends Component {
   }
 
   update (color) {
-    this.setState({ color });
-    this.throttle(this.props.onChange, this.output());
+    this.setState({ color }, () => {
+      this.throttle(this.props.onChange, this.output());
+    });
   }
 
   output () {


### PR DESCRIPTION
Clicking on the color picker doesn't choose the right color for the first time. 
The update function set the color to the state and then calls the throttled output function.
The problem is that setState is async and the output (which gets the color from the state) triggers before the state has changed and thus using the previous color before the change.