### PR TITLE
Handle React peer dependency range >= 15.6.1 #35

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "tinycolor2": "^1.3.0"
   },
   "peerDependencies": {
-    "react": "^15.6.1 || ^16.0.0"
+    "react": ">= 15.6.1"
   }
 }


### PR DESCRIPTION
I've tested coloreact on my project with React 17 and everything works nicely.
Let's remove the React peer dependency upper bound range so it's up to the user to find out if it works with newer React versions 😉 

Closes #35 